### PR TITLE
Add example confidence thresholding

### DIFF
--- a/src/opencv_example.cc
+++ b/src/opencv_example.cc
@@ -93,6 +93,11 @@ int main() {
 
     // Process the resulting bounding-boxes if there are any
     for (auto &p : predictions) {
+      // Filter out low-confidence predictions, adjust the threshold as needed
+      if (p.confidence < 0.5f) {
+        continue;
+      }
+
       auto x_min =
           std::max(0, std::min(static_cast<int>(p.x_min * width), width - 1));
       auto y_min =


### PR DESCRIPTION
I noticed that there was no confidence thresholding, so depending on the Plumerai People Detection library used, it might be good to have some thresholding. The current value used is only 0.5, so that is not too high. Users can set it as they want of course; this way they have an example to get started.