### PR TITLE
Add optional RTSP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plumerai People Detection OpenCV pipeline example
 
-This is the source code for a simple version of using the Plumerai People Detection library in an end-to-end demo setting. It runs on Linux, uses OpenCV and V4L, and retrieves input data from a webcam and writes box coordinates to console and to an output video stream displayed on screen. It can be modified as needed for proto-typing with the Plumerai People Detection library.
+This is the source code for a simple version of using the Plumerai People Detection library in an end-to-end demo setting. It runs on Linux, uses OpenCV and V4L, and retrieves input data from a webcam (or optionally an RTSP stream) and writes box coordinates to console and to an output video stream displayed on screen. It can be modified as needed for proto-typing with the Plumerai People Detection library.
 
 The Plumerai People Detection library itself is not included: this repository can't be used without access to the library. If you do not have access to the library and would like to evaluate it, then contact us at [plumerai.com/contact_us](https://plumerai.com/contact_us). For more information, see [plumerai.com/people-detection](https://plumerai.com/people-detection).
 
@@ -21,6 +21,10 @@ First, make sure the camera settings (`camera_height`, `camera_width`, and `came
 The higher the input resolution, the better the results can become. However, note that this might slow down the entire example application, because the camera capture and video-displaying might take up more resources. The framerate reported is purely for the Plumerai People Detection algorithm itself, and does not count camera capture or displaying of the results.
 
 Note that the example application itself (the camera capture / video decoding and displaying) is not optimized for speed. Furthermore, the people detection algorithm in its current form is not optimized for speed on x86 systems, only for targets such as Arm Cortex-A.
+
+## Optional: use an RTSP stream as input
+
+This repository also contains example code to use an RTSP video stream instead of camera data as input. The code changes are minimal, and can be enabled by uncommenting the `#define USE_RTSP_INPUT` macro  near the top of the `src/opencv_example.cc` file. Then, a little bit below the RTSP stream settings (`camera_height`, `camera_width`, and `rtsp_url`) can be changed as needed.
 
 ## Compiling the example application
 

--- a/src/opencv_example.cc
+++ b/src/opencv_example.cc
@@ -23,10 +23,22 @@
 // how to use it.
 #include "plumerai/people_detection.h"
 
+// Enable this marco to switch the input of this example application from
+// camera input to RTSP stream:
+// #define USE_RTSP_INPUT
+
+// Input RTSP stream settings (change as needed)
+#ifdef USE_RTSP_INPUT
+constexpr auto width = 240;
+constexpr auto height = 161;
+constexpr auto rtsp_url =
+    "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
+#else
 // Input camera settings (change as needed)
 constexpr auto width = 1280;
 constexpr auto height = 720;
 constexpr auto camera_id = 0;  // 0 == the first camera, 1 == the second, etc.
+#endif  // USE_RTSP_INPUT
 
 // The following line sets the capture API to Video4Linux. Change this as needed
 // on your system. See the OpenCV website for a list of all options:
@@ -57,14 +69,19 @@ int main() {
   cv::namedWindow(window_text, cv::WINDOW_AUTOSIZE);
 
   // Set-up the camera, see the above constants for the settings
+#ifdef USE_RTSP_INPUT
+  cv::VideoCapture camera(rtsp_url);
+#else
   cv::VideoCapture camera(camera_id, camera_capture_api);
   camera.set(cv::CAP_PROP_FRAME_WIDTH, width);
   camera.set(cv::CAP_PROP_FRAME_HEIGHT, height);
   camera.set(cv::CAP_PROP_FOURCC, camera_capture_format);
+#endif  // USE_RTSP_INPUT
   if (!camera.isOpened()) {
-    // If this is printed the camera might not be attached or it might not
-    // support the settings set above (width & height, capture API or format)
-    printf("Error: Could not open camera %d, verify the settings\n", camera_id);
+    // If this is printed the camera might not be attached, the stream might not
+    // be valid or they might not support the settings set above (width &
+    // height, capture API or format).
+    printf("Error: Could not open the input, verify the settings\n");
     return -1;
   }
 


### PR DESCRIPTION
This makes some minimal code changes to show how an RTSP stream can be used with OpenCV. The new code is entirely optional: default behaviour is unchanged. I updated the README regarding the new feature. I tested it on the given example `rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4` stream.